### PR TITLE
Add Prism-based topology discovery

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -15,4 +15,6 @@ const (
 	CustomPENameLabel   string = "nutanix.com/prism-element-name"
 	CustomHostUUIDLabel string = "nutanix.com/prism-host-uuid"
 	CustomHostNameLabel string = "nutanix.com/prism-host-name"
+
+	PrismCentralService string = "PRISM_CENTRAL"
 )

--- a/internal/testing/mock/constants.go
+++ b/internal/testing/mock/constants.go
@@ -1,10 +1,11 @@
 package mock
 
 const (
-	MockIP      = "1.1.1.1"
-	MockCluster = "mock-cluster"
-	MockRegion  = "mock-region"
-	MockZone    = "mock-zone"
+	MockIP           = "1.1.1.1"
+	MockCluster      = "mock-cluster"
+	MockPrismCentral = "mock-pc"
+	MockRegion       = "mock-region"
+	MockZone         = "mock-zone"
 
 	MockDefaultRegion = "region"
 	MockDefaultZone   = "zone"

--- a/internal/testing/mock/helpers.go
+++ b/internal/testing/mock/helpers.go
@@ -69,6 +69,13 @@ func getDefaultClusterSpec(clusterName string) *prismClientV3.ClusterIntentRespo
 		Spec: &prismClientV3.Cluster{
 			Name: utils.StringPtr(clusterName),
 		},
+		Status: &prismClientV3.ClusterDefStatus{
+			Resources: &prismClientV3.ClusterObj{
+				Config: &prismClientV3.ClusterConfig{
+					ServiceList: make([]*string, 0),
+				},
+			},
+		},
 	}
 }
 
@@ -112,6 +119,9 @@ func GenerateMockConfig() config.Config {
 				Namespace: mockNamespace,
 			},
 		},
+		TopologyDiscovery: config.TopologyDiscovery{
+			Type: config.PrismTopologyDiscoveryType,
+		},
 	}
 }
 
@@ -130,5 +140,13 @@ func CheckAdditionalLabels(node *v1.Node, vm *prismClientV3.VMIntentResponse) {
 		toMatchKeys[constants.CustomHostNameLabel] = Equal(*vm.Status.Resources.HostReference.Name)
 	}
 
-	Expect(node.Labels).To(gstruct.MatchKeys(gstruct.IgnoreMissing, toMatchKeys))
+	Expect(node.Labels).To(gstruct.MatchAllKeys(toMatchKeys))
+}
+
+func CreatePrismCentralCluster(clusterName string) *prismClientV3.ClusterIntentResponse {
+	pc := getDefaultClusterSpec(clusterName)
+	pc.Status.Resources.Config.ServiceList = []*string{
+		utils.StringPtr(constants.PrismCentralService),
+	}
+	return pc
 }

--- a/internal/testing/mock/mock_prism.go
+++ b/internal/testing/mock/mock_prism.go
@@ -21,3 +21,14 @@ func (mp *MockPrism) GetVM(vmUUID string) (*prismClientV3.VMIntentResponse, erro
 func (mp *MockPrism) GetCluster(clusterUUID string) (*prismClientV3.ClusterIntentResponse, error) {
 	return mp.mockEnvironment.managedMockClusters[clusterUUID], nil
 }
+
+func (mp *MockPrism) ListAllCluster(fitler string) (*prismClientV3.ClusterListIntentResponse, error) {
+	entities := make([]*prismClientV3.ClusterIntentResponse, 0)
+
+	for _, e := range mp.mockEnvironment.managedMockClusters {
+		entities = append(entities, e)
+	}
+	return &prismClientV3.ClusterListIntentResponse{
+		Entities: entities,
+	}, nil
+}

--- a/manifests/cm.yaml
+++ b/manifests/cm.yaml
@@ -16,8 +16,12 @@ data:
           "name": "nutanix-creds"
         }
       },
-      "topologyCategories": {
-        "region": "${NUTANIX_REGION_CATEGORY}",
-        "zone": "${NUTANIX_ZONE_CATEGORY}"
+      "enableCustomLabeling": false,
+      "topologyDiscovery": {
+        "type": "Categories",
+        "topologyCategories": {
+          "regionCategory": "${NUTANIX_REGION_CATEGORY}",
+          "zoneCategory": "${NUTANIX_ZONE_CATEGORY}"
+        }
       }
     }

--- a/pkg/provider/interfaces/interfaces.go
+++ b/pkg/provider/interfaces/interfaces.go
@@ -13,4 +13,5 @@ type Client interface {
 type Prism interface {
 	GetVM(vmUUID string) (*prismClientV3.VMIntentResponse, error)
 	GetCluster(clusterUUID string) (*prismClientV3.ClusterIntentResponse, error)
+	ListAllCluster(filter string) (*prismClientV3.ClusterListIntentResponse, error)
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,7 +1,7 @@
 package provider
 
 import (
-	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -37,10 +37,9 @@ func newNtnxCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		return nil, err
 	}
 
-	nutanixConfig := config.Config{}
-	err = json.Unmarshal(bytes, &nutanixConfig)
+	nutanixConfig, err := config.NewConfigFromBytes(bytes)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error occurred while loading config file: %v", err)
 	}
 	nutanixManager, err := newNutanixManager(nutanixConfig)
 	if err != nil {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -17,10 +17,7 @@ import (
 )
 
 var _ = Describe("Test Provider", func() {
-	const (
-		mockReaderValue      = "mock-reader"
-		expectedProvidername = "nutanix"
-	)
+	const mockReaderValue = "mock-reader"
 
 	var (
 		kClient   *fake.Clientset
@@ -36,7 +33,7 @@ var _ = Describe("Test Provider", func() {
 			config: c,
 		}
 		ntnxCloud = NtnxCloud{
-			name:   expectedProvidername,
+			name:   constants.ProviderName,
 			config: c,
 			manager: &nutanixManager{
 				config:        c,
@@ -131,11 +128,64 @@ var _ = Describe("Test Provider", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("should fail topologyCategories are not set but discovery type is Categories", func() {
+			config := config.Config{
+				TopologyDiscovery: config.TopologyDiscovery{
+					Type: config.CategoriesTopologyDiscoveryType,
+				},
+			}
+			cBytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			cReader := bytes.NewReader(cBytes)
+			_, err = newNtnxCloud(cReader)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail if invalid topology discovery type is passed", func() {
+			config := config.Config{
+				TopologyDiscovery: config.TopologyDiscovery{
+					Type: "invalid",
+				},
+			}
+			cBytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			cReader := bytes.NewReader(cBytes)
+			_, err = newNtnxCloud(cReader)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail if invalid topology discovery type is passed", func() {
+			config := config.Config{
+				TopologyDiscovery: config.TopologyDiscovery{
+					Type: "invalid",
+				},
+			}
+			cBytes, err := json.Marshal(config)
+			Expect(err).ToNot(HaveOccurred())
+			cReader := bytes.NewReader(cBytes)
+			_, err = newNtnxCloud(cReader)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should default to Prism topology Discovery", func() {
+			c := config.Config{
+				TopologyDiscovery: config.TopologyDiscovery{},
+			}
+			cBytes, err := json.Marshal(c)
+			Expect(err).ToNot(HaveOccurred())
+			cReader := bytes.NewReader(cBytes)
+			_, err = newNtnxCloud(cReader)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should return valid NtnxCloud when valid reader is passed", func() {
 			config := config.Config{
-				TopologyCategories: &config.TopologyCategories{
-					Region: mock.MockDefaultRegion,
-					Zone:   mock.MockDefaultZone,
+				TopologyDiscovery: config.TopologyDiscovery{
+					Type: config.CategoriesTopologyDiscoveryType,
+					TopologyCategories: &config.TopologyCategories{
+						RegionCategory: mock.MockDefaultRegion,
+						ZoneCategory:   mock.MockDefaultZone,
+					},
 				},
 			}
 			cJson, err := json.Marshal(config)


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows Category based topology and also Prism based topology (PC = Region, PE=Zone). Also makes enabling custom labels optional.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**How Has This Been Tested?**:
make unit-test

```
Ran 62 of 62 Specs in 0.210 seconds
SUCCESS! -- 62 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestCloudProviderNutanix (0.21s)
PASS
coverage: 83.0% of statements
```

**Special notes for your reviewer**:
This PR changes the configmap structure used by CCM

**Release note**:
```release-note
- Adds Topology discovery based on Prism where PC indicates region and PE zone
```