### PR TITLE
ocp specific makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,14 @@
 # Image URL to use all building/pushing image targets
 IMG ?= nutanix-cloud-controller-manager:latest
-VERSION = 1.0.0
-
-all: build image
+VERSION = 0.1.0
 
 build: vendor
 	GO111MODULE=on CGO_ENABLED=0 go build -ldflags="-w -s -X 'main.version=${VERSION}'" -o=bin/nutanix-cloud-controller-manager main.go
-
-image:
-	docker build -t ${IMG} -f ./Dockerfile.openshift .
 
 vendor:
 	go mod tidy
 	go mod vendor
 	go mod verify
-
 
 ## --------------------------------------
 ## Unit tests
@@ -26,4 +20,10 @@ unit-test:
 
 .PHONY: unit-test-html
 unit-test-html: unit-test
-	go tool cover -html=cover.out 
+	go tool cover -html=cover.out
+
+## --------------------------------------
+## OpenShift specific include
+## --------------------------------------
+
+include ./openshift/openshift.mk

--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 
 WORKDIR /build
 COPY . .
-RUN make build
+RUN make openshift-build
 
 FROM registry.ci.openshift.org/ocp/4.12:base
 

--- a/openshift/openshift.mk
+++ b/openshift/openshift.mk
@@ -1,0 +1,9 @@
+## --------------------------------------
+## OpenShift specific make targets
+## --------------------------------------
+
+openshift-image:
+	docker build -t ${IMG} -f ./openshift/Dockerfile.openshift .
+
+openshift-build: vendor
+	GO111MODULE=on CGO_ENABLED=0 go build -ldflags="-w -s -X 'main.version=${VERSION}'" -o=bin/nutanix-cloud-controller-manager main.go


### PR DESCRIPTION
Since OCP is not the only, nor primary, consumer of CCM, this PR moves OCP specific make config to openshift includes file for better organization. Note that this PR does not provide support for standard make config. 