### PR TITLE
Update Prism Go Client dependency to v0.3.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/nutanix-cloud-native/cloud-provider-nutanix
 
-go 1.17
+go 1.19
 
 require (
 	github.com/google/uuid v1.3.0
-	github.com/nutanix-cloud-native/prism-go-client v0.3.2
+	github.com/nutanix-cloud-native/prism-go-client v0.3.4
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	k8s.io/api v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nutanix-cloud-native/prism-go-client v0.3.2 h1:rw+Je85dzyoTjM5ntybw/Tnyf7rLeSsM26Tl3pXDEVs=
-github.com/nutanix-cloud-native/prism-go-client v0.3.2/go.mod h1:tTIH02E6o6AWSShr98QChoxuZl+jBhkXFixom9+fd1Y=
+github.com/nutanix-cloud-native/prism-go-client v0.3.4 h1:bHY3VPrHHYnbRtkpGaKK+2ZmvUjNVRC55CYZbXIfnOk=
+github.com/nutanix-cloud-native/prism-go-client v0.3.4/go.mod h1:tTIH02E6o6AWSShr98QChoxuZl+jBhkXFixom9+fd1Y=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
**What this PR does / why we need it**:
The updated version of the Prism Go Client can handle trust bundle stored as BinaryData in a config map.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes the failing CCM e2e test in https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/pull/171

**How Has This Been Tested?**:
Built a new image and ran the CCM e2e test on CAPX. The e2e test was failing prior to this change.
```
➜  cluster-api-provider-nutanix git:(additional-trust-bundle) export CCM_REPO='public.ecr.aws/g7v6l0u0/nutanix-cloud-native/cloud-provider-nutanix'
➜  cluster-api-provider-nutanix git:(additional-trust-bundle) export CCM_TAG='sid.shukla'
➜  cluster-api-provider-nutanix git:(additional-trust-bundle) LABEL_FILTERS="ccm"  make test-e2e-calico
...
Will run 1 of 23 specs
------------------------------
STEP: Initializing a runtime.Scheme with all the GVK relevant for this test 11/25/22 02:16:57.694
STEP: Loading the e2e test configuration from "/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/config/nutanix.yaml" 11/25/22 02:16:57.695
STEP: Creating a clusterctl local repository into "/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/_artifacts" 11/25/22 02:16:57.698
STEP: Reading the ClusterResourceSet manifest /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/data/cni/calico/calico.yaml 11/25/22 02:16:57.698
STEP: Setting up the bootstrap cluster 11/25/22 02:17:14.613
STEP: Creating the bootstrap cluster 11/25/22 02:17:14.613
Creating cluster "test-zfhhrk" ...
 • Ensuring node image (kindest/node:v1.23.6) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.23.6) 🖼
 • Preparing nodes 📦   ...
 ✓ Preparing nodes 📦
 • Writing configuration 📜  ...
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Installing CNI 🔌  ...
 ✓ Installing CNI 🔌
 • Installing StorageClass 💾  ...
 ✓ Installing StorageClass 💾

STEP: Initializing the bootstrap cluster 11/25/22 02:18:50.789
STEP: Waiting for deployment capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager to be available 11/25/22 02:20:04.071
STEP: Waiting for deployment capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager to be available 11/25/22 02:20:04.086
STEP: Waiting for deployment capi-system/capi-controller-manager to be available 11/25/22 02:20:04.116
STEP: Waiting for deployment capx-system/capx-controller-manager to be available 11/25/22 02:20:04.131
[SynchronizedBeforeSuite] TOP-LEVEL
  /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/e2e_suite_test.go:119
---
• [SLOW TEST] [164.808 seconds]
Nutanix flavor CCM [capx-feature-test, ccm, slow, network]
/Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/ccm_test.go:33
  Create a cluster with Nutanix CCM
  /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/ccm_test.go:68

  Begin Captured GinkgoWriter Output >>
    [BeforeEach] Nutanix flavor CCM
      /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/ccm_test.go:51
    STEP: Creating a namespace for hosting the "cluster-ccm" test spec 11/25/22 02:20:05.672
    [It] Create a cluster with Nutanix CCM
      /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/ccm_test.go:68
    STEP: Creating a workload cluster 11/25/22 02:20:05.692
    STEP: Waiting for cluster to enter the provisioned phase 11/25/22 02:20:07.642
    STEP: Waiting for one control plane node to exist 11/25/22 02:20:17.684
    STEP: Waiting for the control plane to be ready 11/25/22 02:21:07.734
    STEP: Checking all the the control plane machines are in the expected failure domains 11/25/22 02:21:37.738
    STEP: Waiting for the workload nodes to exist 11/25/22 02:21:37.76
    STEP: Checking all the machines controlled by cluster-ccm-jozsyc-wmd are in the "<None>" failure domain 11/25/22 02:21:57.787
    STEP: Fetching workload proxy 11/25/22 02:21:57.823
    STEP: Checking if nodes have correct CCM labels 11/25/22 02:21:57.85
    STEP: PASSED! 11/25/22 02:21:58.909
    [AfterEach] Nutanix flavor CCM
      /Users/sid.shukla/go/src/github.com/nutanix-cloud-native/cluster-api-provider-nutanix/test/e2e/ccm_test.go:64
    STEP: Dumping logs from the "cluster-ccm-jozsyc" workload cluster 11/25/22 02:21:58.909
    STEP: Dumping all the Cluster API resources in the "cluster-ccm-cf3a6a" namespace 11/25/22 02:21:59.023
    STEP: Deleting cluster cluster-ccm-cf3a6a/cluster-ccm-jozsyc 11/25/22 02:21:59.196
    STEP: Deleting cluster cluster-ccm-jozsyc 11/25/22 02:21:59.212
    STEP: Waiting for cluster cluster-ccm-jozsyc to be deleted 11/25/22 02:21:59.231
    STEP: Deleting namespace used for hosting the "cluster-ccm" test spec 11/25/22 02:22:49.259

Ran 1 of 23 Specs in 360.159 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 22 Skipped
PASS

Ginkgo ran 1 suite in 6m10.677047441s
Test Suite Passed
```

**Release note**:
```release-note
- Can handle Trust Bundle stored in BinaryData inside a ConfigMap
```