### PR TITLE
OCPBUGS-17054: Nutanix CCM should scope secret informers per namespace

### DIFF
--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -19,7 +19,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 
 	prismgoclient "github.com/nutanix-cloud-native/prism-go-client"
 	"github.com/nutanix-cloud-native/prism-go-client/environment"
@@ -32,7 +31,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	"github.com/nutanix-cloud-native/cloud-provider-nutanix/internal/constants"
 	"github.com/nutanix-cloud-native/cloud-provider-nutanix/pkg/provider/config"
 	"github.com/nutanix-cloud-native/cloud-provider-nutanix/pkg/provider/interfaces"
 )
@@ -86,7 +84,7 @@ func (n *nutanixClient) setupEnvironment() error {
 	if n.env != nil {
 		return nil
 	}
-	ccmNamespace, err := n.getCCMNamespace()
+	ccmNamespace, err := GetCCMNamespace()
 	if err != nil {
 		return err
 	}
@@ -126,12 +124,4 @@ func (n *nutanixClient) syncCache(informer cache.SharedInformer) {
 			klog.Fatal("failed to wait for caches to sync")
 		}
 	}
-}
-
-func (n *nutanixClient) getCCMNamespace() (string, error) {
-	ns := os.Getenv(constants.CCMNamespaceKey)
-	if ns == "" {
-		return "", fmt.Errorf("failed to retrieve CCM namespace. Make sure %s env variable is set", constants.CCMNamespaceKey)
-	}
-	return ns, nil
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"io/ioutil"
 
-	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
@@ -79,11 +78,6 @@ func (nc *NtnxCloud) Initialize(clientBuilder cloudprovider.ControllerClientBuil
 	klog.Info("Initializing client ...")
 	nc.addKubernetesClient(clientBuilder.ClientOrDie("cloud-provider-nutanix"))
 	klog.Infof("Client initialized")
-}
-
-// SetInformers sets the informer on the cloud object. Implements cloudprovider.InformerUser
-func (nc *NtnxCloud) SetInformers(informerFactory informers.SharedInformerFactory) {
-	nc.manager.setInformers(informerFactory)
 }
 
 func (nc *NtnxCloud) addKubernetesClient(kclient clientset.Interface) {

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -19,12 +19,11 @@ package provider
 import (
 	"bytes"
 	"encoding/json"
+	"os"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/nutanix-cloud-native/cloud-provider-nutanix/internal/constants"
@@ -57,14 +56,7 @@ var _ = Describe("Test Provider", func() {
 			},
 			instancesV2: &instancesV2{},
 		}
-	})
-
-	Context("Test SetInformers", func() {
-		It("should set the informers", func() {
-			informerFactory := informers.NewSharedInformerFactory(kClient, time.Minute)
-			ntnxCloud.SetInformers(informerFactory)
-			Expect(nClient.env).To(BeNil())
-		})
+		os.Setenv(constants.CCMNamespaceKey, "ccm-namespace")
 	})
 
 	Context("Test AddKubernetesClient", func() {

--- a/pkg/provider/utils.go
+++ b/pkg/provider/utils.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/nutanix-cloud-native/cloud-provider-nutanix/internal/constants"
+)
+
+// GetCCMNamespace returns the CCM controller pod namespace
+func GetCCMNamespace() (string, error) {
+	ns := os.Getenv(constants.CCMNamespaceKey)
+	if ns == "" {
+		return "", fmt.Errorf("failed to retrieve CCM namespace. Make sure %s env variable is set", constants.CCMNamespaceKey)
+	}
+	return ns, nil
+}
+
+// NoResyncPeriodFunc returns the 0 resync period
+func NoResyncPeriodFunc() time.Duration {
+	return 0
+}


### PR DESCRIPTION
What this PR does / why we need it:
To restrict the RBAC scope of CCM, this PR updates the way Nutanix CCM watches secrets/configmaps to only watch the required namespaces.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
[OCPBUGS-17054](https://issues.redhat.com/browse/OCPBUGS-17054)

How Has This Been Tested?:
Manually tested with the OCP 4.14.0-ec.3 Nutanix cluster, with the locally built nutanix-ccm image of this PR's code changes.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output

Special notes for your reviewer:

Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

Release note: