### PR TITLE
Do not log node exists/shutdown status at default verbosity

### DIFF
--- a/pkg/provider/manager.go
+++ b/pkg/provider/manager.go
@@ -194,10 +194,8 @@ func (n *nutanixManager) nodeExists(ctx context.Context, node *v1.Node) (bool, e
 		if !strings.Contains(fmt.Sprint(err), "ENTITY_NOT_FOUND") {
 			return false, err
 		}
-		klog.Infof("Node %s does not exist!", node.Name)
 		return false, nil
 	}
-	klog.Infof("Node %s exists!", node.Name)
 	return true, nil
 }
 
@@ -215,10 +213,8 @@ func (n *nutanixManager) isNodeShutdown(ctx context.Context, node *v1.Node) (boo
 		return false, err
 	}
 	if n.isVMShutdown(vm) {
-		klog.Infof("Node %s is shutdown!", node.Name)
 		return true, nil
 	}
-	klog.Infof("Node %s is not shutdown!", node.Name)
 	return false, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cloud-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Previously, the controller logged two lines for every node approximately every 7 seconds, or about 1000 lines per node, per hour.


For example:
```log
I1227 18:39:59.655871       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:00.115157       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:00.693491       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:01.242311       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:06.775496       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:07.264917       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:07.747176       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:08.179592       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:13.675784       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:14.156767       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:14.635342       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:15.065686       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:20.463439       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:20.963273       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:21.388286       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:21.864284       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:27.416278       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:27.998769       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:28.646187       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:29.131304       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:34.683511       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:35.118103       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:35.694925       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:36.122100       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:41.666251       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:42.244924       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:42.669489       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:43.234134       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:48.753024       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:49.212019       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:49.864969       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:50.358605       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:40:55.896952       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:40:56.365655       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:40:56.908435       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:40:57.474351       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:41:03.086870       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:41:03.708390       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:41:04.286242       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:41:04.694276       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:41:10.260410       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:41:10.911270       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:41:11.510154       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:41:12.153530       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:41:17.836055       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:41:18.429313       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:41:18.988415       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:41:19.486467       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:41:25.096248       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:41:25.613627       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
I1227 18:41:26.205629       1 manager.go:190] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml exists!
I1227 18:41:26.784818       1 manager.go:211] Node my-cc-cluster-md-0-d8drs-g2hdp-q4xml is not shutdown!
I1227 18:41:32.304919       1 manager.go:190] Node my-cc-cluster-qh6fc-plnhl exists!
I1227 18:41:32.876564       1 manager.go:211] Node my-cc-cluster-qh6fc-plnhl is not shutdown!
```

Moreover, nearly identical messages are already logged in a different function, at verbosity level 1:
- https://github.com/nutanix-cloud-native/cloud-provider-nutanix/blob/712bb7d673f03e63269677f1435c8d8ab681ceb5/pkg/provider/instances_v2.go#L42
- https://github.com/nutanix-cloud-native/cloud-provider-nutanix/blob/712bb7d673f03e63269677f1435c8d8ab681ceb5/pkg/provider/instances_v2.go#L51

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```