### PR TITLE
Switch Nutanix Client to using Session Auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ bin/
 _artifacts
 profile.cov
 coverage.xml
+.idea/
 

--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -55,11 +55,12 @@ func (n *nutanixClient) Get() (interfaces.Prism, error) {
 		return nil, err
 	}
 	creds := &prismgoclient.Credentials{
-		URL:      me.Address.Host, // Not really an URL
-		Endpoint: me.Address.Host,
-		Insecure: me.Insecure,
-		Username: me.ApiCredentials.Username,
-		Password: me.ApiCredentials.Password,
+		URL:         me.Address.Host, // Not really an URL
+		Endpoint:    me.Address.Host,
+		Insecure:    me.Insecure,
+		Username:    me.ApiCredentials.Username,
+		Password:    me.ApiCredentials.Password,
+		SessionAuth: true,
 	}
 
 	clientOpts := make([]prismClientV3.ClientOption, 0)


### PR DESCRIPTION
This will ensure we make fewer basic auth requests to Prism Central IAM Services.