### PR TITLE
Add the checkout ref for incorporating PR

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       # Install nix using cachix/install-nix-action if running on ARC runners
       # See: https://github.com/DeterminateSystems/nix-installer-action/issues/68

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
 
       - name: Install devbox
         run: curl -fsSL https://get.jetpack.io/devbox | bash -s -- -f


### PR DESCRIPTION
Since we moved to using pull_request_target which executes the workflow in the context of the base repository but the default HEAD that gets checked out is now the main branch rather than the PR. This ensures the pull request HEAD is checked out before running the workflow.