### PR TITLE
Update the checkout sha for github actions

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@v0.11.0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
 
       # Install nix using cachix/install-nix-action if running on ARC runners
       # See: https://github.com/DeterminateSystems/nix-installer-action/issues/68

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
 
       - name: Install devbox
         run: curl -fsSL https://get.jetpack.io/devbox | bash -s -- -f


### PR DESCRIPTION
`github.event.pull_request.merge_commit_sha` seems to have some buggy behavior.
