### PR TITLE
fix(rbac): add read access to services

### DIFF
--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -16,14 +16,8 @@ rules:
       - ""
     resources:
       - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
       - configmaps
+      - services
     verbs:
       - get
       - list


### PR DESCRIPTION
**What this PR does / why we need it**:
Add services RO permission to the `system:cloud-controller-manager` cluster role.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #190 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix(rbac): allow cloud controller manager to read services
```