### PR TITLE
fix(build): Add local registry login to e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,6 +54,13 @@ jobs:
             exit 1
           fi
 
+      - name: Login to Internal Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.LOCAL_IMAGE_REGISTRY }}
+          username: ${{ secrets.LOCAL_IMAGE_REGISTRY_USERNAME }}
+          password: ${{ secrets.LOCAL_IMAGE_REGISTRY_TOKEN }}
+
       - name: Test build
         run: devbox run -- make test-e2e LABEL_FILTERS='${{ inputs.e2e-labels }}'
         env:


### PR DESCRIPTION
E2E pushes images to local registry and needs access to registry.
actions are on pull_request_target so failures in the PR are expected failures.