### PR TITLE
Skip updating node status address if already set

### DIFF
--- a/pkg/provider/manager.go
+++ b/pkg/provider/manager.go
@@ -299,18 +299,14 @@ func (n *nutanixManager) generateProviderID(ctx context.Context, vmUUID string) 
 
 	return fmt.Sprintf("%s://%s", constants.ProviderName, strings.ToLower(vmUUID)), nil
 }
+
 func (n *nutanixManager) isNodeAddressesSet(node *v1.Node) bool {
 	if node == nil {
 		return false
 	}
 
-	nodeAddresses := node.Status.Addresses
-	if len(nodeAddresses) < 2 { // We set at least two addresses on a node: one internal IP and one hostname
-		return false
-	}
-
 	var hasHostname, hasInternalIP bool
-	for _, address := range nodeAddresses {
+	for _, address := range node.Status.Addresses {
 		if address.Type == v1.NodeHostName {
 			hasHostname = true
 		}
@@ -320,6 +316,8 @@ func (n *nutanixManager) isNodeAddressesSet(node *v1.Node) bool {
 		}
 	}
 
+	// We always set at least two address types: one internal IP and one hostname.
+	// If either type is not found, then we have not set the node addresses.
 	return hasHostname && hasInternalIP
 }
 

--- a/pkg/provider/manager_unit_test.go
+++ b/pkg/provider/manager_unit_test.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestIsNodeAddressesSet(t *testing.T) {
+	tests := []struct {
+		name string
+		node *v1.Node
+		want bool
+	}{
+		{
+			name: "found an internalIP and a hostname",
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeHostName,
+							Address: "example.com",
+						},
+						{
+							Type:    v1.NodeInternalIP,
+							Address: "1.2.3.4",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "found only internalIPs",
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeInternalIP,
+							Address: "1.2.3.4",
+						},
+						{
+							Type:    v1.NodeInternalIP,
+							Address: "5.6.7.8",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "found only a hostname",
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeHostName,
+							Address: "example.com",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "found no addresses",
+			node: &v1.Node{
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &nutanixManager{}
+			if got := n.isNodeAddressesSet(tt.node); got != tt.want {
+				t.Errorf("nutanixManager.isNodeAddressesSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If node status addresses field has already been set, we want to skip updating it again. This is to work around sporadic API issues that don't guarantee in the ordering between learned IPs based on source i.e DHCP assigned IP priority before loadbalancer ARP-ed IP.