### PR TITLE
Fix panic in getNodeAddresses when vm has no NicList

### DIFF
--- a/internal/testing/mock/mock_environment.go
+++ b/internal/testing/mock/mock_environment.go
@@ -104,7 +104,7 @@ func CreateMockEnvironment(ctx context.Context, kClient *fake.Clientset) (*MockE
 	}
 
 	noAddressesVM := getDefaultVMSpec(MockVMNameNoAddresses, cluster)
-	noAddressesVM.Status.Resources.NicList = []*prismClientV3.VMNicOutputStatus{}
+	noAddressesVM.Status.Resources.NicList = nil
 	noAddressesNode, err := createNodeForVM(ctx, kClient, noAddressesVM)
 	if err != nil {
 		return nil, err

--- a/pkg/provider/manager_test.go
+++ b/pkg/provider/manager_test.go
@@ -117,6 +117,22 @@ var _ = Describe("Test Manager", func() {
 			Expect(err).Should(HaveOccurred())
 		})
 
+		It("should fail if nil vm status is passed", func() {
+			vm := mockEnvironment.GetVM(ctx, mock.MockVMNameNoAddresses)
+			Expect(vm).ToNot(BeNil())
+			vm.Status = nil
+			_, err := m.getNodeAddresses(ctx, vm)
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("should fail if nil resources is passed", func() {
+			vm := mockEnvironment.GetVM(ctx, mock.MockVMNameNoAddresses)
+			Expect(vm).ToNot(BeNil())
+			vm.Status.Resources = nil
+			_, err := m.getNodeAddresses(ctx, vm)
+			Expect(err).Should(HaveOccurred())
+		})
+
 		It("should fail if no node addresses are found", func() {
 			vm := mockEnvironment.GetVM(ctx, mock.MockVMNameNoAddresses)
 			Expect(vm).ToNot(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cloud-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Adds nil value check in the getNodeAddresses function to avoid accessing nil value array. Also added `vm.Status == nil || vm.Status.Resources == nil`  just in case that was the reason for the panic.

Encountered this panic in our E2E suite when deleting the machine.
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_machine-api-provider-nutanix/90/pull-ci-openshift-machine-api-provider-nutanix-main-e2e-nutanix-operator/1891596566960017408

This was caused because of omitEmpty empty nicList gets unmarshalled into nil value.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**How Has This Been Tested?**:
Added unit test.


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix panic when getting node addresses from vm with no network interfaces.
```