### PR TITLE
fix(deps): update devbox.lock

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -389,6 +389,9 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/3a05eebede89661660945da1f151959900903b6a?lastModified=1740547748&narHash=sha256-Ly2fBL1LscV%2BKyCqPRufUBuiw%2BzmWrlJzpWOWbahplg%3D"
+    },
     "gnumake@latest": {
       "last_modified": "2024-09-10T15:01:03Z",
       "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#gnumake",


### PR DESCRIPTION
new version of devbox is out and it makes a small change to the devbox.lock. Committing the change to prevent failing builds.
