### PR TITLE
fix(build): allow internal contributors to test workflows

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -4,7 +4,12 @@ on:
     branches:
       - main
       - 'release-*'
+  pull_request:
+    paths:
+      - '.github/**'
   pull_request_target:
+    paths-ignore:
+      - '.github/**'
 jobs:
   build-container:
     runs-on: ubuntu-latest

--- a/.github/workflows/synopsys.yaml
+++ b/.github/workflows/synopsys.yaml
@@ -1,11 +1,15 @@
 name: Black Duck Policy Check
 on:
-  pull_request_target:
   push:
     branches:
       - main
       - 'release-*'
-
+  pull_request:
+    paths:
+      - '.github/**'
+  pull_request_target:
+    paths-ignore:
+      - '.github/**'
 jobs:
   security:
     if: github.repository == 'nutanix-cloud-native/cloud-provider-nutanix'


### PR DESCRIPTION
Allows internal contributors to test workflow changes. Workflow changes will run using pull_request event. If a workflow uses secrets and is run in an external PR, the workflow will not be able to read the secrets. Non-workflow changes will run using pull_request_target.