### PR TITLE
fix: set predictable and proper server IP addresses order

### DIFF
--- a/pkg/provider/manager.go
+++ b/pkg/provider/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"sort"
 	"strings"
 
 	convergedV4 "github.com/nutanix-cloud-native/prism-go-client/converged/v4"
@@ -498,7 +499,14 @@ func (n *nutanixManager) getNodeAddressesFromNicNetworkInfo(ipv4Config *vmmModel
 			}
 		}
 	}
-	return addressSet.Slice(), nil
+
+	// Callers rely on the order of the addresses, so we sort them to ensure consistency.
+	addresses := addressSet.Slice()
+	sort.Slice(addresses, func(i, j int) bool {
+		return addresses[i].Address < addresses[j].Address
+	})
+
+	return addresses, nil
 }
 
 func (n *nutanixManager) stripNutanixIDFromProviderID(providerID string) string {

--- a/pkg/provider/manager.go
+++ b/pkg/provider/manager.go
@@ -379,8 +379,8 @@ func (n *nutanixManager) isNodeAddressesSet(node *v1.Node) bool {
 }
 
 func (n *nutanixManager) getNodeAddresses(_ context.Context, vm *vmmModels.Vm) ([]v1.NodeAddress, error) {
-	var addressSet *set.Set[v1.NodeAddress]
 	var addresses []v1.NodeAddress
+	uniqueIPs := set.New[string](0)
 
 	if vm == nil {
 		return nil, fmt.Errorf("vm cannot be nil when getting node addresses")
@@ -390,36 +390,48 @@ func (n *nutanixManager) getNodeAddresses(_ context.Context, vm *vmmModels.Vm) (
 		return nil, fmt.Errorf("unable to determine network interfaces from VM with UUID %s: vm has no nics", *vm.ExtId)
 	}
 
-	addressSet = set.From([]v1.NodeAddress{}) //nolint:typecheck
 	for _, nic := range vm.Nics {
 		if nic.NicNetworkInfo == nil {
 			continue
 		}
 
+		var vmAddresses []v1.NodeAddress
+		var err error
 		switch nic.NicNetworkInfo.GetValue().(type) {
 		case vmmModels.VirtualEthernetNicNetworkInfo:
 			netInfo := nic.NicNetworkInfo.GetValue().(vmmModels.VirtualEthernetNicNetworkInfo)
-			vmAddressSet, err := n.getNodeAddressesFromNicNetworkInfo(netInfo.Ipv4Config, netInfo.Ipv4Info)
+
+			vmAddresses, err = n.getNodeAddressesFromNicNetworkInfo(netInfo.Ipv4Config, netInfo.Ipv4Info)
 			if err != nil {
 				return nil, err
 			}
-			addressSet.InsertSlice(vmAddressSet)
 
 		case vmmModels.DpOffloadNicNetworkInfo:
 			netInfo := nic.NicNetworkInfo.GetValue().(vmmModels.DpOffloadNicNetworkInfo)
-			vmAddressSet, err := n.getNodeAddressesFromNicNetworkInfo(netInfo.Ipv4Config, netInfo.Ipv4Info)
+			vmAddresses, err = n.getNodeAddressesFromNicNetworkInfo(netInfo.Ipv4Config, netInfo.Ipv4Info)
 			if err != nil {
 				return nil, err
 			}
-			addressSet.InsertSlice(vmAddressSet)
 
 		default:
 			klog.V(1).Infof("unsupported NIC network info type: %T", nic.NicNetworkInfo.GetValue()) //nolint:typecheck
 			continue
 		}
-	}
 
-	addresses = append(addresses, addressSet.Slice()...)
+		// At this point, every NIC has no duplicates in its own set of addresses.
+		// However, there can be duplicates across the sets of addresses of different NICs,
+		// so we ignore the duplicates.
+		for _, addr := range vmAddresses {
+			if addr.Type != v1.NodeInternalIP {
+				addresses = append(addresses, addr)
+				continue
+			}
+			if !uniqueIPs.Contains(addr.Address) {
+				uniqueIPs.Insert(addr.Address)
+				addresses = append(addresses, addr)
+			}
+		}
+	}
 
 	if len(addresses) == 0 {
 		return addresses, fmt.Errorf("unable to determine network interfaces from VM with UUID %s", *vm.ExtId)

--- a/pkg/provider/manager_unit_test.go
+++ b/pkg/provider/manager_unit_test.go
@@ -1,9 +1,16 @@
 package provider
 
 import (
+	"context"
+	"net/netip"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	vmmCommonModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/common/v1/config"
+	vmmModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/config"
+	"go4.org/netipx"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestIsNodeAddressesSet(t *testing.T) {
@@ -79,5 +86,216 @@ func TestIsNodeAddressesSet(t *testing.T) {
 				t.Errorf("nutanixManager.isNodeAddressesSet() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetNodeAddresses(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		vm            *vmmModels.Vm
+		wantErr       bool
+		wantAddresses []v1.NodeAddress
+	}{
+		{
+			name: "VM with no NICs returns error",
+			vm: vmWithNICS(
+				t,
+				"my-vm",
+				"uuid-1",
+				[]vmmModels.Nic{},
+			),
+			wantErr: true,
+		},
+		{
+			name: "VM with one NIC returns internal IP and hostname",
+			vm: vmWithNICS(
+				t,
+				"my-vm",
+				"uuid-1",
+				[]vmmModels.Nic{
+					nicWithIPs(t, "10.0.0.1", []string{"10.0.0.2"}, []string{"10.0.0.3"}),
+				},
+			),
+			wantAddresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.2",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.3",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "my-vm",
+				},
+			},
+		},
+		{
+			name: "VM with two NICs, each with different internal IPs: addresses appear in NIC order",
+			vm: vmWithNICS(
+				t,
+				"my-vm",
+				"uuid-2",
+				[]vmmModels.Nic{
+					nicWithIPs(t, "10.0.0.1", []string{"10.0.0.2", "10.0.0.3"}, []string{"10.0.0.4"}),
+					nicWithIPs(t, "10.0.0.5", []string{"10.0.0.6", "10.0.0.7"}, []string{"10.0.0.8"}),
+				}),
+			wantAddresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.2",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.3",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.5",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.6",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.7",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.8",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "my-vm",
+				},
+			},
+		},
+		{
+			name: "VM with two NICs, each with the same internal IP: the internal IP appears once",
+			vm: vmWithNICS(
+				t,
+				"my-vm",
+				"uuid-3",
+				[]vmmModels.Nic{
+					nicWithIPs(t, "10.0.0.1", []string{"10.0.0.2"}, []string{"10.0.0.3"}),
+					nicWithIPs(t, "10.0.0.1", []string{"10.0.0.4"}, []string{"10.0.0.5"}),
+				}),
+			wantAddresses: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.2",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.3",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.5",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "my-vm",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &nutanixManager{
+				// We have to initialize ignoredNodeIPs, or the test will fail with a nil pointer dereference.
+				ignoredNodeIPs: ignoredIPSet("10.0.0.99"),
+			}
+			gotAddresses, err := m.getNodeAddresses(ctx, tt.vm)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("getNodeAddresses() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("getNodeAddresses() err = %v", err)
+				return
+			}
+
+			if diff := cmp.Diff(tt.wantAddresses, gotAddresses); diff != "" {
+				t.Errorf("getNodeAddresses() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ignoredIPSet(ips ...string) *netipx.IPSet {
+	b := netipx.IPSetBuilder{}
+	for _, s := range ips {
+		b.Add(netip.MustParseAddr(s))
+	}
+	s, _ := b.IPSet()
+	return s
+}
+
+// nicWithIP returns a NIC with the given IPv4 address.
+func nicWithIPs(t *testing.T, primaryIP string, secondaryIPs []string, learnedIPs []string) vmmModels.Nic {
+	t.Helper()
+	netInfo := vmmModels.NewVirtualEthernetNicNetworkInfo()
+
+	netInfo.Ipv4Config = vmmModels.NewIpv4Config()
+	netInfo.Ipv4Config.IpAddress = &vmmCommonModels.IPv4Address{Value: ptr.To(primaryIP)}
+	netInfo.Ipv4Config.SecondaryIpAddressList = make([]vmmCommonModels.IPv4Address, 0, len(secondaryIPs))
+	for _, secondaryIP := range secondaryIPs {
+		netInfo.Ipv4Config.SecondaryIpAddressList = append(
+			netInfo.Ipv4Config.SecondaryIpAddressList,
+			vmmCommonModels.IPv4Address{Value: ptr.To(secondaryIP)},
+		)
+	}
+
+	netInfo.Ipv4Info = vmmModels.NewIpv4Info()
+	netInfo.Ipv4Info.LearnedIpAddresses = make([]vmmCommonModels.IPv4Address, 0, len(learnedIPs))
+	for _, learnedIP := range learnedIPs {
+		netInfo.Ipv4Info.LearnedIpAddresses = append(
+			netInfo.Ipv4Info.LearnedIpAddresses,
+			vmmCommonModels.IPv4Address{Value: ptr.To(learnedIP)},
+		)
+	}
+
+	nic := vmmModels.NewNic()
+	if err := nic.SetNicNetworkInfo(*netInfo); err != nil {
+		t.Fatalf("SetNicNetworkInfo: %v", err)
+	}
+	return *nic
+}
+
+// vmWithNICS returns a VM with the given NICs.
+func vmWithNICS(t *testing.T, name, uuid string, nics []vmmModels.Nic) *vmmModels.Vm {
+	t.Helper()
+	return &vmmModels.Vm{
+		ExtId: ptr.To(uuid),
+		Name:  ptr.To(name),
+		Nics:  nics,
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cloud-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

CCM: when configured with mutiple subnet, CCM does not preseve subnet order for InternalIP.

**Which issue(s) this PR fixes** :
Fixes: https://jira.nutanix.com/browse/NCN-112212

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```