### PR TITLE
fix: Upgrade Trivy action and configure trivyignore

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -85,7 +85,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@v0.35.0
         env:
           TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
         with:
@@ -95,6 +95,7 @@ jobs:
           exit-code: "1"
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
   e2e:
     strategy:
       matrix:

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -39,7 +39,7 @@ jobs:
           devbox run -- ko build -B -t ${{ github.sha }} --platform=$PLATFORMS .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@v0.35.0
         env:
           TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
         with:
@@ -47,6 +47,7 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,5 @@
 # False positive, fix is present in v2.16.0 https://github.com/emicklei/go-restful/commit/ac666c045e035603f2704c98c59e979fccbfa94f
 CVE-2022-1996
+# Pending fix in separate dependency PR
+CVE-2026-24051
+CVE-2026-33186


### PR DESCRIPTION
## Summary
Updates Trivy configuration and tooling to fix scanning issues in cloud-provider-nutanix.

## Changes
- **Trivy action**: Upgrade `aquasecurity/trivy-action` from `0.29.0` to `v0.35.0` in `build-dev.yaml` and `trivy-scan.yaml`
- **Trivy ignore config**: Add `trivyignores: ".trivyignore"` so both workflows use the ignore file
- **`.trivyignore`**: Add CVE-2026-24051 and CVE-2026-33186 (to be addressed in a separate dependency upgrade PR)

## Motivation
- Newer trivy-action versions improve scanning and fix known issues
- Using `.trivyignore` prevents known/false positives from failing CI
- CVE-2026-24051 (otel/sdk) and CVE-2026-33186 (grpc) are planned for a future dependency update