### PR TITLE
feat: support nodeSelector for instances

### DIFF
--- a/pkg/provider/config/config.go
+++ b/pkg/provider/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	credentialTypes "github.com/nutanix-cloud-native/prism-go-client/environment/credentials"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klog "k8s.io/klog/v2"
 )
 
@@ -30,6 +31,8 @@ type Config struct {
 	TopologyDiscovery    TopologyDiscovery                    `json:"topologyDiscovery"`
 	EnableCustomLabeling bool                                 `json:"enableCustomLabeling"`
 	IgnoredNodeIPs       []string                             `json:"ignoredNodeIPs,omitempty"`
+	// NodeSelector restricts which nodes this CCM processes. If nil or empty, all nodes are processed.
+	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty" yaml:"nodeSelector,omitempty"`
 }
 
 type TopologyDiscovery struct {

--- a/pkg/provider/instances_v2.go
+++ b/pkg/provider/instances_v2.go
@@ -35,6 +35,12 @@ func newInstancesV2(nutanixManager *nutanixManager) cloudprovider.InstancesV2 {
 }
 
 func (i *instancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
+	if matches, err := i.nutanixManager.nodeMatchesSelector(node); err != nil {
+		return false, err
+	} else if !matches {
+		klog.V(4).InfoS("InstanceExists: node not selected, skipping", "node", node.Name) //nolint:typecheck
+		return true, nil
+	}
 	ok, err := i.nutanixManager.nodeExists(ctx, node)
 	if err != nil {
 		return ok, err
@@ -44,6 +50,12 @@ func (i *instancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, 
 }
 
 func (i *instancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+	if matches, err := i.nutanixManager.nodeMatchesSelector(node); err != nil {
+		return false, err
+	} else if !matches {
+		klog.V(4).InfoS("InstanceShutdown: node not selected, skipping", "node", node.Name) //nolint:typecheck
+		return false, nil
+	}
 	ok, err := i.nutanixManager.isNodeShutdown(ctx, node)
 	if err != nil {
 		return ok, err
@@ -53,6 +65,12 @@ func (i *instancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool
 }
 
 func (i *instancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+	if matches, err := i.nutanixManager.nodeMatchesSelector(node); err != nil {
+		return nil, err
+	} else if !matches {
+		klog.V(4).InfoS("InstanceMetadata: node not selected, skipping", "node", node.Name) //nolint:typecheck
+		return &cloudprovider.InstanceMetadata{ProviderID: node.Spec.ProviderID}, nil
+	}
 	md, err := i.nutanixManager.getInstanceMetadata(ctx, node)
 	if err != nil {
 		return md, err

--- a/pkg/provider/manager.go
+++ b/pkg/provider/manager.go
@@ -32,6 +32,8 @@ import (
 	vmmModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/config"
 	"go4.org/netipx"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
@@ -716,4 +718,15 @@ func (n *nutanixManager) hasPEClusterServiceEnabled(cluster *clusterModels.Clust
 		}
 	}
 	return false
+}
+
+func (n *nutanixManager) nodeMatchesSelector(node *v1.Node) (bool, error) {
+	if n.config.NodeSelector == nil {
+		return true, nil
+	}
+	selector, err := metav1.LabelSelectorAsSelector(n.config.NodeSelector)
+	if err != nil {
+		return false, fmt.Errorf("invalid nodeSelector: %v", err)
+	}
+	return selector.Matches(labels.Set(node.Labels)), nil
 }

--- a/pkg/provider/manager_unit_test.go
+++ b/pkg/provider/manager_unit_test.go
@@ -10,7 +10,10 @@ import (
 	vmmModels "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/models/vmm/v4/ahv/config"
 	"go4.org/netipx"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/nutanix-cloud-native/cloud-provider-nutanix/pkg/provider/config"
 )
 
 func TestIsNodeAddressesSet(t *testing.T) {
@@ -297,5 +300,103 @@ func vmWithNICS(t *testing.T, name, uuid string, nics []vmmModels.Nic) *vmmModel
 		ExtId: ptr.To(uuid),
 		Name:  ptr.To(name),
 		Nics:  nics,
+	}
+}
+
+func TestNodeMatchesSelector(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeLabels   map[string]string
+		nodeSelector *metav1.LabelSelector
+		want         bool
+		wantErr      bool
+	}{
+		{
+			name:         "nil selector matches all nodes",
+			nodeLabels:   map[string]string{"foo": "bar"},
+			nodeSelector: nil,
+			want:         true,
+		},
+		{
+			name:       "matchLabels: node matches",
+			nodeLabels: map[string]string{"role": "worker"},
+			nodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "worker"},
+			},
+			want: true,
+		},
+		{
+			name:       "matchLabels: node does not match",
+			nodeLabels: map[string]string{"role": "control-plane"},
+			nodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "worker"},
+			},
+			want: false,
+		},
+		{
+			name:       "matchExpressions In: node matches",
+			nodeLabels: map[string]string{"zone": "us-east-1a"},
+			nodeSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "zone",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"us-east-1a", "us-east-1b"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name:       "matchExpressions NotIn: node is excluded",
+			nodeLabels: map[string]string{"zone": "us-east-1a"},
+			nodeSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "zone",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"us-east-1a"},
+				}},
+			},
+			want: false,
+		},
+		{
+			name:       "matchExpressions NotIn: node without the label matches",
+			nodeLabels: map[string]string{},
+			nodeSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "zone",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"us-east-1a"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name:       "matchLabels + matchExpressions NotIn: both must hold",
+			nodeLabels: map[string]string{"role": "worker", "zone": "us-east-1a"},
+			nodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "worker"},
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      "zone",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"us-east-1a"},
+				}},
+			},
+			want: false, // NotIn fails even though matchLabels passes
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &nutanixManager{
+				config: config.Config{NodeSelector: tt.nodeSelector},
+			}
+			node := &v1.Node{}
+			node.Labels = tt.nodeLabels
+			got, err := m.nodeMatchesSelector(node)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("nodeMatchesSelector() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("nodeMatchesSelector() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cloud-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
In order to support mixed clusters with Nodes from different infrastructures, add a `nodeSelector` configuration which contains matchLabels and matchExpressions for selection of which Nodes should be processed by this CCM.

This is a new optional field so it will continue to work as is if `nodeSelector` is not set.

Here's an example of how it can be used to select all Nodes that don't match a particular label:
```
  "nodeSelector": {
    "matchExpressions": [
      {
        "key": "nutanix.com/node-type",
        "operator": "NotIn",
        "values": ["another-type"]
      }
    ]
  }
```
In mixed cluster, where a Nodepool can be created with a different infra provider, this CCM would be configured to match all Nodes that don't have a particular label. Then the CCM for the other infra provider would have the inverse selector where it would match labels with that particular label. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_
Added new unit tests.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
feat: support nodeSelector for instances
```