### PR TITLE
fix: use toolchain to set go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/nutanix-cloud-native/cloud-provider-nutanix
 
 go 1.25.0
 
+toolchain go1.26.4
+
 require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/nutanix-cloud-native/prism-go-client v0.7.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,6 +2,8 @@ module github.com/nutanix-cloud-native/cloud-provider-nutanix/test/e2e
 
 go 1.25.0
 
+toolchain go1.26.4
+
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1


### PR DESCRIPTION
bump go toolchain to fix stdlib cves
